### PR TITLE
Add GitHub Actions workflow for Cloudflare Workers deployment

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  # Run every 4 hours
+  schedule:
+    - cron: '0 */4 * * *'
+  # Allow manual workflow dispatch
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Cloudflare Workers
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy


### PR DESCRIPTION
- Runs every 4 hours on a schedule
- Can be manually triggered via workflow_dispatch
- Uses official Cloudflare Wrangler action (v3)
- Builds with npm run build and deploys with Wrangler
- Requires CLOUDFLARE_API_TOKEN secret to be configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)