### PR TITLE
Add YOUTUBE_API_KEY environment variable to build step

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build project
         run: npm run build
+        env:
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
Set YOUTUBE_API_KEY from repository secrets during the build step in the GitHub Actions workflow to ensure the YouTube API key is available when building the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)