### PR TITLE
Add robots.txt allowing all crawlers and pointing to sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://buildatscale.tv/sitemap.xml


### PR DESCRIPTION
Summary of the task and what was done. Original ask: Add a robots.txt file under /public that allows all crawlers and points to the sitemap