### PR TITLE
Add newsletter signup thank you page

### DIFF
--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -160,34 +160,8 @@ const interests = [
         throw new Error(result.error || 'Failed to subscribe');
       }
 
-      // Show success state
-      submitBtn?.removeAttribute('disabled');
-      submitText!.textContent = 'Subscribe';
-      arrow?.classList.remove('hidden');
-      spinner?.classList.add('hidden');
-      successMsg?.classList.remove('hidden');
-
-      // Update success message if it's a duplicate
-      if (result.message) {
-        successText!.textContent = result.message;
-      } else {
-        successText!.textContent = 'Successfully subscribed!';
-      }
-
-      // Reset form
-      (e.target as HTMLFormElement).reset();
-
-      // Reset interest buttons
-      selectedInterests.clear();
-      interestBtns.forEach(btn => {
-        btn.classList.remove('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
-        btn.classList.add('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
-      });
-
-      // Hide success message after 3 seconds
-      setTimeout(() => {
-        successMsg?.classList.add('hidden');
-      }, 3000);
+      // Redirect to thank you page on success
+      window.location.href = '/newsletter-thank-you';
     } catch (error) {
       // Show error state
       submitBtn?.removeAttribute('disabled');

--- a/src/pages/newsletter-thank-you.astro
+++ b/src/pages/newsletter-thank-you.astro
@@ -1,0 +1,56 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<Layout
+  title="Thank You for Subscribing — BuildAtScale"
+  description="You've successfully subscribed to the BuildAtScale newsletter."
+>
+  <Header />
+  <main class="min-h-[60vh] flex items-center justify-center px-4 sm:px-6 lg:px-8 py-16 bg-blue-50 dark:bg-slate-800">
+    <div class="max-w-2xl mx-auto text-center">
+      <div class="mb-6">
+        <div class="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg class="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+      </div>
+
+      <h1 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+        You're Subscribed!
+      </h1>
+
+      <p class="text-lg text-gray-600 dark:text-gray-300 mb-8">
+        Thanks for joining the BuildAtScale newsletter. You'll be the first to know about new content on AI orchestration, development workflows, and the latest experiments.
+      </p>
+
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a
+          href="/"
+          class="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-lg font-medium transition-colors"
+        >
+          Back to Home
+        </a>
+        <a
+          href="https://youtube.com/@buildatscale?sub_confirmation=1"
+          target="_blank"
+          rel="noopener"
+          class="bg-red-600 hover:bg-red-700 text-white px-8 py-3 rounded-lg font-medium transition-colors flex items-center space-x-2"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+          </svg>
+          <span>Subscribe on YouTube</span>
+        </a>
+      </div>
+
+      <p class="mt-8 text-sm text-gray-500 dark:text-gray-400">
+        No spam, ever. Unsubscribe at any time. I respect your privacy.
+      </p>
+    </div>
+  </main>
+  <Footer />
+</Layout>


### PR DESCRIPTION
This change adds a dedicated thank you page at /newsletter-thank-you to provide a better post-subscription experience. The newsletter form on the homepage now redirects users to this page after a successful signup instead of showing a brief inline message. The page includes a confirmation message, links back to the home page, and an option to subscribe on YouTube.

Request:
> create newsletter signup thank you page