### PR TITLE
refactor: modernize dark mode with deeper palette and enhanced depth

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -19,12 +19,12 @@ const topics = [
 ];
 ---
 
-<section id="about" class="py-16 bg-blue-50 dark:bg-slate-800 transition-colors">
+<section id="about" class="py-16 bg-blue-50 dark:bg-slate-900 transition-colors">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
       <div class="flex flex-col sm:flex-row gap-6 items-center sm:items-start">
         <!-- Avatar -->
-        <div class="flex-shrink-0 w-[120px] h-[120px] rounded-full border-4 border-white dark:border-slate-700 shadow-lg overflow-hidden bg-[#1e3049]">
+        <div class="flex-shrink-0 w-[120px] h-[120px] rounded-full border-4 border-white dark:border-slate-700/50 shadow-lg dark:shadow-black/30 overflow-hidden bg-[#1e3049]">
           <img
             src="/images/avatar-small.png"
             alt="Ronnie - BuildAtScale"
@@ -62,7 +62,7 @@ const topics = [
         </h3>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {topics.map((topic) => (
-            <div class="bg-white dark:bg-slate-700/50 backdrop-blur-sm border border-gray-200 dark:border-slate-600 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/30 transition-shadow">
+            <div class="bg-white dark:bg-slate-800/60 backdrop-blur-sm border border-gray-200 dark:border-slate-700/50 rounded-lg p-4 hover:shadow-md dark:hover:shadow-blue-900/10 transition-shadow">
               <div class="flex items-center space-x-3">
                 <div class="text-blue-600 dark:text-blue-400" set:html={topic.icon} />
                 <span class="font-medium text-gray-900 dark:text-gray-100">{topic.label}</span>
@@ -71,7 +71,7 @@ const topics = [
           ))}
         </div>
 
-        <div class="mt-8 p-6 bg-white dark:bg-slate-700/50 backdrop-blur-sm border border-blue-200 dark:border-slate-600 rounded-lg">
+        <div class="mt-8 p-6 bg-white dark:bg-slate-800/60 backdrop-blur-sm border border-blue-200 dark:border-slate-700/50 rounded-lg">
           <h4 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">
             Learning by Doing
           </h4>
@@ -86,16 +86,16 @@ const topics = [
 </section>
 
 <!-- Subtle divider after about -->
-<div class="bg-blue-50 dark:bg-slate-800">
+<div class="bg-blue-50 dark:bg-slate-900">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center gap-4 py-8">
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-700 to-transparent"></div>
       <div class="flex gap-1.5">
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-400"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-600"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-600"></div>
       </div>
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-700 to-transparent"></div>
     </div>
   </div>
 </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 import Logo from './Logo.astro';
 ---
 
-<footer class="bg-white dark:bg-slate-900 border-t border-gray-200 dark:border-slate-700 py-12 transition-colors">
+<footer class="bg-white dark:bg-slate-950 border-t border-gray-200 dark:border-slate-800/50 py-12 transition-colors">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex flex-col md:flex-row items-center justify-between">
       <div class="flex items-center space-x-2 mb-4 md:mb-0">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,7 @@ import Logo from './Logo.astro';
 import ThemeToggle from './ThemeToggle.astro';
 ---
 
-<header class="bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm border-b border-gray-200 dark:border-slate-800 sticky top-0 z-50 transition-colors">
+<header class="bg-white/95 dark:bg-slate-950/80 backdrop-blur-md border-b border-gray-200 dark:border-slate-800/50 sticky top-0 z-50 transition-colors">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
       <!-- Logo -->

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,7 +1,7 @@
 ---
 ---
 
-<section class="bg-gradient-to-b from-blue-50 to-white dark:from-slate-700 dark:to-slate-800 pt-20 pb-10 transition-colors">
+<section class="bg-gradient-to-b from-blue-50 to-white dark:from-slate-950 dark:via-slate-900 dark:to-slate-900 pt-20 pb-10 transition-colors">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-16">
       <h1 class="text-5xl lg:text-6xl font-bold text-gray-900 dark:text-gray-100 mb-6">
@@ -28,7 +28,7 @@
         </a>
         <a
           href="#latest"
-          class="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-3 rounded-lg font-medium transition-colors"
+          class="border-2 border-blue-600 dark:border-blue-400 text-blue-600 dark:text-blue-400 hover:bg-blue-600 hover:text-white dark:hover:bg-blue-500/20 dark:hover:text-blue-300 px-8 py-3 rounded-lg font-medium transition-colors"
         >
           Browse Videos
         </a>

--- a/src/components/LatestVideos.astro
+++ b/src/components/LatestVideos.astro
@@ -67,7 +67,7 @@ const videosData = sortedVideos.map(video => ({
 }));
 ---
 
-<section id="videos" class="py-16 bg-gray-50 dark:bg-slate-700 transition-colors">
+<section id="videos" class="py-16 bg-gray-50 dark:bg-slate-800 transition-colors">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
       <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
@@ -87,8 +87,8 @@ const videosData = sortedVideos.map(video => ({
           data-video-ids={JSON.stringify(playlist.videoIds)}
           class={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
             index === 0
-              ? 'bg-blue-600 text-white shadow-md'
-              : 'bg-white dark:bg-slate-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-500 border border-gray-200 dark:border-slate-500'
+              ? 'bg-blue-600 text-white shadow-md dark:shadow-blue-900/30'
+              : 'bg-white dark:bg-slate-700/60 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-600/60 border border-gray-200 dark:border-slate-600/50'
           }`}
         >
           {playlist.label}
@@ -134,7 +134,7 @@ const videosData = sortedVideos.map(video => ({
         data-videos={JSON.stringify(videosData)}
         data-most-popular={mostPopularVideo?.id}
         data-total={totalVideos}
-        class="inline-flex items-center space-x-2 bg-gray-100 hover:bg-gray-200 dark:bg-slate-600 dark:hover:bg-slate-500 text-gray-900 dark:text-gray-100 px-6 py-3 rounded-lg font-medium transition-colors"
+        class="inline-flex items-center space-x-2 bg-gray-100 hover:bg-gray-200 dark:bg-slate-700/60 dark:hover:bg-slate-600/60 text-gray-900 dark:text-gray-100 px-6 py-3 rounded-lg font-medium transition-colors border border-transparent dark:border-slate-600/50"
       >
         <span id="btn-text">View More Videos</span>
         <svg id="btn-icon-more" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -149,8 +149,8 @@ const videosData = sortedVideos.map(video => ({
 </section>
 
 <WaveTransition
-  topColor="fill-gray-50 dark:fill-slate-700"
-  bottomColor="fill-blue-50 dark:fill-slate-800"
+  topColor="fill-gray-50 dark:fill-slate-800"
+  bottomColor="fill-blue-50 dark:fill-slate-900"
 />
 
 <script>
@@ -266,9 +266,9 @@ const videosData = sortedVideos.map(video => ({
           <button
             type="button"
             onclick="openVideoModal('${video.id}', '${escapedTitle}')"
-            class="bg-white dark:bg-slate-600/50 backdrop-blur-sm border border-gray-200 dark:border-slate-500 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-slate-700/30 transition-all duration-300 group cursor-pointer block w-full text-left"
+            class="bg-white dark:bg-slate-800/60 backdrop-blur-sm border border-gray-200 dark:border-slate-700/50 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-blue-900/10 transition-all duration-300 group cursor-pointer block w-full text-left"
           >
-            <div class="relative aspect-video bg-gray-100 dark:bg-gray-800">
+            <div class="relative aspect-video bg-gray-100 dark:bg-slate-900">
               <img
                 src="${video.thumbnail}"
                 alt="${video.title}"
@@ -392,11 +392,11 @@ const videosData = sortedVideos.map(video => ({
 
         // Update active state
         filterButtons.forEach(btn => {
-          btn.classList.remove('bg-blue-600', 'text-white', 'shadow-md');
-          btn.classList.add('bg-white', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-slate-500', 'border', 'border-gray-200', 'dark:border-slate-500');
+          btn.classList.remove('bg-blue-600', 'text-white', 'shadow-md', 'dark:shadow-blue-900/30');
+          btn.classList.add('bg-white', 'dark:bg-slate-700/60', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-slate-600/60', 'border', 'border-gray-200', 'dark:border-slate-600/50');
         });
-        button.classList.remove('bg-white', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-slate-500', 'border', 'border-gray-200', 'dark:border-slate-500');
-        button.classList.add('bg-blue-600', 'text-white', 'shadow-md');
+        button.classList.remove('bg-white', 'dark:bg-slate-700/60', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-slate-600/60', 'border', 'border-gray-200', 'dark:border-slate-600/50');
+        button.classList.add('bg-blue-600', 'text-white', 'shadow-md', 'dark:shadow-blue-900/30');
 
         currentFilter = filterId;
         renderFilteredVideos();

--- a/src/components/MostRecentVideo.astro
+++ b/src/components/MostRecentVideo.astro
@@ -31,16 +31,16 @@ const latestVideo = hasVideos ? {
 ---
 
 <WaveTransition
-  topColor="fill-white dark:fill-slate-800"
-  bottomColor="fill-gray-50 dark:fill-slate-700"
+  topColor="fill-white dark:fill-slate-900"
+  bottomColor="fill-gray-50 dark:fill-slate-900"
 />
 
-<section id="latest" class="pt-10 pb-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-slate-700 transition-colors">
+<section id="latest" class="pt-10 pb-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-slate-900 transition-colors">
   <div class="max-w-7xl mx-auto">
     {hasVideos && latestVideo ? (
       <div class="max-w-4xl mx-auto">
         <div class="text-center mb-6">
-          <span class="inline-block bg-green-100 dark:bg-green-700/30 text-green-700 dark:text-green-300 px-3 py-1 rounded-full text-sm font-medium mb-4">
+          <span class="inline-block bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 px-3 py-1 rounded-full text-sm font-medium mb-4 border border-green-200 dark:border-green-800/50">
             Latest Video
           </span>
           <h2 class="text-2xl lg:text-3xl font-bold text-gray-900 dark:text-gray-100">
@@ -53,7 +53,7 @@ const latestVideo = hasVideos ? {
           onclick={`openVideoModal('${latestVideo.videoId}', '${latestVideo.title.replace(/'/g, "\\'")}')`}
           class="relative group cursor-pointer block w-full"
         >
-          <div class="relative aspect-video bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden shadow-2xl">
+          <div class="relative aspect-video bg-gray-200 dark:bg-slate-800 rounded-lg overflow-hidden shadow-2xl dark:shadow-black/50">
             <img
               src={latestVideo.thumbnail}
               alt={latestVideo.title}

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -10,21 +10,21 @@ const interests = [
 ---
 
 <!-- Subtle divider between forms -->
-<div class="bg-blue-50 dark:bg-slate-800">
+<div class="bg-blue-50 dark:bg-slate-900">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center gap-4 py-8">
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-700 to-transparent"></div>
       <div class="flex gap-1.5">
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-400"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-600"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-600"></div>
       </div>
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-700 to-transparent"></div>
     </div>
   </div>
 </div>
 
-<section class="py-12 pb-24 bg-blue-50 dark:bg-slate-800 text-gray-900 dark:text-white">
+<section class="py-12 pb-24 bg-blue-50 dark:bg-slate-950 text-gray-900 dark:text-white">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
       <h2 class="text-3xl lg:text-4xl font-bold mb-4">
@@ -36,7 +36,7 @@ const interests = [
       </p>
     </div>
 
-    <div class="bg-white dark:bg-slate-700/50 backdrop-blur-sm rounded-lg p-8 shadow-lg dark:shadow-slate-700/50 border border-gray-200 dark:border-slate-600">
+    <div class="bg-white dark:bg-slate-800/60 backdrop-blur-sm rounded-lg p-8 shadow-lg dark:shadow-black/20 border border-gray-200 dark:border-slate-700/50">
       <form id="newsletter-form" class="space-y-6">
         <div>
           <label for="signup-email" class="block text-sm font-medium text-gray-700 dark:text-gray-400 mb-2">
@@ -46,7 +46,7 @@ const interests = [
             type="email"
             id="signup-email"
             name="email"
-            class="w-full px-4 py-3 bg-white dark:bg-slate-600/80 border border-gray-300 dark:border-slate-500 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            class="w-full px-4 py-3 bg-white dark:bg-slate-900/60 border border-gray-300 dark:border-slate-600/60 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             placeholder="your@email.com"
             required
           />
@@ -61,7 +61,7 @@ const interests = [
               <button
                 type="button"
                 data-interest={interest}
-                class="interest-btn px-3 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-slate-600 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-500 border border-gray-300 dark:border-slate-500 break-words text-center min-h-[2.5rem] flex items-center justify-center"
+                class="interest-btn px-3 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-slate-700/60 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-600/60 border border-gray-300 dark:border-slate-600/50 break-words text-center min-h-[2.5rem] flex items-center justify-center"
               >
                 {interest}
               </button>
@@ -119,10 +119,10 @@ const interests = [
         if (selectedInterests.has(interest)) {
           selectedInterests.delete(interest);
           btn.classList.remove('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
-          btn.classList.add('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
+          btn.classList.add('bg-gray-100', 'dark:bg-slate-700/60', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-600/60', 'border-gray-300', 'dark:border-slate-600/50');
         } else {
           selectedInterests.add(interest);
-          btn.classList.remove('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
+          btn.classList.remove('bg-gray-100', 'dark:bg-slate-700/60', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-600/60', 'border-gray-300', 'dark:border-slate-600/50');
           btn.classList.add('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
         }
       }
@@ -181,7 +181,7 @@ const interests = [
       selectedInterests.clear();
       interestBtns.forEach(btn => {
         btn.classList.remove('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
-        btn.classList.add('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
+        btn.classList.add('bg-gray-100', 'dark:bg-slate-700/60', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-600/60', 'border-gray-300', 'dark:border-slate-600/50');
       });
 
       // Hide success message after 3 seconds

--- a/src/components/RequestForm.astro
+++ b/src/components/RequestForm.astro
@@ -8,7 +8,7 @@ const requestTypes = [
 ];
 ---
 
-<section class="py-8 pb-12 bg-blue-50 dark:bg-slate-800">
+<section class="py-8 pb-12 bg-blue-50 dark:bg-slate-900">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
       <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
@@ -20,7 +20,7 @@ const requestTypes = [
       </p>
     </div>
 
-    <div class="bg-white dark:bg-slate-700/50 backdrop-blur-sm rounded-lg shadow-lg dark:shadow-slate-700/50 p-8 border border-transparent dark:border-slate-600">
+    <div class="bg-white dark:bg-slate-800/60 backdrop-blur-sm rounded-lg shadow-lg dark:shadow-black/20 p-8 border border-transparent dark:border-slate-700/50">
       <form id="request-form" class="space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
@@ -31,7 +31,7 @@ const requestTypes = [
               type="text"
               id="name"
               name="name"
-              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600/60 bg-white dark:bg-slate-900/60 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               required
             />
           </div>
@@ -43,7 +43,7 @@ const requestTypes = [
               type="email"
               id="request-email"
               name="email"
-              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600/60 bg-white dark:bg-slate-900/60 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               required
             />
           </div>
@@ -53,11 +53,11 @@ const requestTypes = [
           <label for="type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Request Type
           </label>
-          <select
-            id="type"
-            name="type"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent [&>option]:bg-white [&>option]:dark:bg-slate-800 [&>option]:text-gray-900 [&>option]:dark:text-gray-100"
-          >
+            <select
+              id="type"
+              name="type"
+              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600/60 bg-white dark:bg-slate-900/60 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent [&>option]:bg-white [&>option]:dark:bg-slate-900 [&>option]:text-gray-900 [&>option]:dark:text-gray-100"
+            >
             {requestTypes.map((type) => (
               <option value={type}>{type}</option>
             ))}
@@ -68,14 +68,14 @@ const requestTypes = [
           <label for="message" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Details
           </label>
-          <textarea
-            id="message"
-            name="message"
-            rows="4"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400 dark:placeholder-gray-500"
-            placeholder="Describe your idea, problem, or request in detail..."
-            required
-          ></textarea>
+            <textarea
+              id="message"
+              name="message"
+              rows="4"
+              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600/60 bg-white dark:bg-slate-900/60 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400 dark:placeholder-gray-500"
+              placeholder="Describe your idea, problem, or request in detail..."
+              required
+            ></textarea>
         </div>
 
         <div class="flex flex-col space-y-4">

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,7 +6,7 @@
   <button
     id="theme-toggle"
     type="button"
-    class="p-2 rounded-lg bg-gray-100 dark:bg-slate-800 hover:bg-gray-200 dark:hover:bg-slate-700 transition-colors border border-transparent dark:border-slate-700"
+    class="p-2 rounded-lg bg-gray-100 dark:bg-slate-800/60 hover:bg-gray-200 dark:hover:bg-slate-700/60 transition-colors border border-transparent dark:border-slate-700/50"
     aria-label="Toggle theme"
   >
     <svg id="theme-icon-light" class="w-5 h-5 text-gray-800 dark:text-gray-200 hidden" fill="currentColor" viewBox="0 0 20 20">

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -21,10 +21,10 @@ const timeAgo = getTimeAgo(publishedAt);
 <button
   type="button"
   onclick={`openVideoModal('${videoId}', '${title.replace(/'/g, "\\'")}')`}
-  class="bg-white dark:bg-slate-600/50 backdrop-blur-sm border border-gray-200 dark:border-slate-500 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-slate-700/30 transition-all duration-300 group cursor-pointer block w-full text-left"
+  class="bg-white dark:bg-slate-800/60 backdrop-blur-sm border border-gray-200 dark:border-slate-700/50 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-blue-900/10 transition-all duration-300 group cursor-pointer block w-full text-left"
 >
   <!-- Video Thumbnail -->
-  <div class="relative aspect-video bg-gray-100 dark:bg-gray-800">
+  <div class="relative aspect-video bg-gray-100 dark:bg-slate-900">
     <img
       src={thumbnail}
       alt={title}

--- a/src/components/VideoModal.astro
+++ b/src/components/VideoModal.astro
@@ -4,8 +4,8 @@
 ---
 
 <dialog id="video-modal" class="backdrop:bg-black backdrop:bg-opacity-75 bg-transparent p-0 max-w-6xl w-full rounded-lg">
-  <div class="bg-white dark:bg-slate-700 rounded-lg overflow-hidden shadow-2xl border border-transparent dark:border-slate-600">
-    <div class="flex items-center justify-between p-4 bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-white border-b border-gray-200 dark:border-slate-500">
+  <div class="bg-white dark:bg-slate-900 rounded-lg overflow-hidden shadow-2xl border border-transparent dark:border-slate-700/50">
+    <div class="flex items-center justify-between p-4 bg-gray-100 dark:bg-slate-800 text-gray-900 dark:text-white border-b border-gray-200 dark:border-slate-700/50">
       <h3 id="video-modal-title" class="text-lg font-semibold text-gray-900 dark:text-white"></h3>
       <button
         id="close-video-modal"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,7 +20,7 @@ const { title, description = "Learning in Public — AI • Web • Ops" } = Ast
     <title>{title}</title>
     <ThemeScript />
   </head>
-  <body class="min-h-screen bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 transition-colors">
+  <body class="min-h-screen bg-white dark:bg-slate-950 text-gray-900 dark:text-gray-100 transition-colors">
     <slot />
   </body>
 </html>


### PR DESCRIPTION
Replaced the flat slate-700/800 backgrounds with a richer layered palette using slate-950/900/800 for better depth and contrast. Cards, forms, and modals now use translucent surfaces with subtler borders and tinted hover shadows for a more modern, elevated feel in dark mode.

Request:
> Variant 1 of 3: dark mode facelift/refresh. Want to focus specifically on the design in dark mode. it currently looks a bit dated / flat. want to improve overall.