### PR TITLE
refactor: dark mode facelift with richer palette and depth

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -19,12 +19,15 @@ const topics = [
 ];
 ---
 
-<section id="about" class="py-16 bg-blue-50 dark:bg-slate-800 transition-colors">
+<section id="about" class="py-16 bg-blue-50 dark:bg-slate-900 transition-colors relative">
+  <div class="absolute inset-0 dark:block hidden pointer-events-none">
+    <div class="absolute top-1/3 right-1/4 w-64 h-64 bg-blue-500/5 rounded-full blur-3xl"></div>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
       <div class="flex flex-col sm:flex-row gap-6 items-center sm:items-start">
         <!-- Avatar -->
-        <div class="flex-shrink-0 w-[120px] h-[120px] rounded-full border-4 border-white dark:border-slate-700 shadow-lg overflow-hidden bg-[#1e3049]">
+        <div class="flex-shrink-0 w-[120px] h-[120px] rounded-full border-4 border-white dark:border-slate-800 shadow-lg overflow-hidden bg-[#1e3049]">
           <img
             src="/images/avatar-small.png"
             alt="Ronnie - BuildAtScale"
@@ -34,10 +37,10 @@ const topics = [
 
         <!-- Text content -->
         <div>
-          <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center sm:text-left">
+          <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-slate-100 mb-6 text-center sm:text-left">
             About BuildAtScale
           </h2>
-          <div class="space-y-4 text-lg text-gray-600 dark:text-gray-300 leading-relaxed">
+          <div class="space-y-4 text-lg text-gray-600 dark:text-slate-300 leading-relaxed">
             <p>
               Lately I'm exploring how to stop writing every line of code myself and start directing
               AI agents to handle development, research, and deployment.
@@ -57,25 +60,25 @@ const topics = [
       </div>
 
       <div id="topics">
-        <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+        <h3 class="text-2xl font-bold text-gray-900 dark:text-slate-100 mb-6">
           What You'll Find Here
         </h3>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {topics.map((topic) => (
-            <div class="bg-white dark:bg-slate-700/50 backdrop-blur-sm border border-gray-200 dark:border-slate-600 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-700/30 transition-shadow">
+            <div class="bg-white dark:bg-slate-800/50 backdrop-blur-sm border border-gray-200 dark:border-slate-700/50 rounded-lg p-4 hover:shadow-md dark:hover:shadow-slate-950/40 transition-shadow dark:hover:ring-1 dark:hover:ring-slate-600/40">
               <div class="flex items-center space-x-3">
                 <div class="text-blue-600 dark:text-blue-400" set:html={topic.icon} />
-                <span class="font-medium text-gray-900 dark:text-gray-100">{topic.label}</span>
+                <span class="font-medium text-gray-900 dark:text-slate-100">{topic.label}</span>
               </div>
             </div>
           ))}
         </div>
 
-        <div class="mt-8 p-6 bg-white dark:bg-slate-700/50 backdrop-blur-sm border border-blue-200 dark:border-slate-600 rounded-lg">
-          <h4 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">
+        <div class="mt-8 p-6 bg-white dark:bg-slate-800/50 backdrop-blur-sm border border-blue-200 dark:border-slate-700/50 rounded-lg dark:hover:shadow-slate-950/40 transition-shadow">
+          <h4 class="font-semibold text-gray-900 dark:text-slate-100 mb-2">
             Learning by Doing
           </h4>
-          <p class="text-gray-600 dark:text-gray-300">
+          <p class="text-gray-600 dark:text-slate-300">
             Not being afraid to show the messy parts. Real experiments, real failures,
             and real discoveries in the world of AI-assisted development.
           </p>
@@ -86,16 +89,16 @@ const topics = [
 </section>
 
 <!-- Subtle divider after about -->
-<div class="bg-blue-50 dark:bg-slate-800">
+<div class="bg-blue-50 dark:bg-slate-900">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center gap-4 py-8">
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-700 to-transparent"></div>
       <div class="flex gap-1.5">
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-400"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-600"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-600"></div>
       </div>
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-700 to-transparent"></div>
     </div>
   </div>
 </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,12 +2,12 @@
 import Logo from './Logo.astro';
 ---
 
-<footer class="bg-white dark:bg-slate-900 border-t border-gray-200 dark:border-slate-700 py-12 transition-colors">
+<footer class="bg-white dark:bg-slate-950 border-t border-gray-200 dark:border-slate-800/60 py-12 transition-colors">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex flex-col md:flex-row items-center justify-between">
       <div class="flex items-center space-x-2 mb-4 md:mb-0">
         <Logo />
-        <span class="font-bold text-xl text-gray-900 dark:text-gray-100">
+        <span class="font-bold text-xl text-gray-900 dark:text-slate-100">
           Build<span class="text-blue-600 dark:text-blue-400">AtScale</span>
         </span>
       </div>
@@ -17,7 +17,7 @@ import Logo from './Logo.astro';
           href="https://github.com/buildatscale-tv"
           target="_blank"
           rel="noopener"
-          class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+          class="text-gray-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
           aria-label="GitHub"
         >
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -28,7 +28,7 @@ import Logo from './Logo.astro';
           href="https://x.com/BuildAtScale"
           target="_blank"
           rel="noopener"
-          class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+          class="text-gray-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
           aria-label="X (Twitter)"
         >
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -39,17 +39,17 @@ import Logo from './Logo.astro';
           href="https://youtube.com/@buildatscale"
           target="_blank"
           rel="noopener"
-          class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+          class="text-gray-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
           aria-label="YouTube"
         >
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
             <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
           </svg>
         </a>
-        <span class="text-gray-400 dark:text-gray-500">•</span>
-        <a href="/privacy" class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-sm">Privacy Policy</a>
-        <span class="text-gray-400 dark:text-gray-500">•</span>
-        <span class="text-gray-600 dark:text-gray-300">buildatscale.tv</span>
+        <span class="text-gray-400 dark:text-slate-600">•</span>
+        <a href="/privacy" class="text-gray-600 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-sm">Privacy Policy</a>
+        <span class="text-gray-400 dark:text-slate-600">•</span>
+        <span class="text-gray-600 dark:text-slate-400">buildatscale.tv</span>
       </div>
     </div>
   </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,26 +3,26 @@ import Logo from './Logo.astro';
 import ThemeToggle from './ThemeToggle.astro';
 ---
 
-<header class="bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm border-b border-gray-200 dark:border-slate-800 sticky top-0 z-50 transition-colors">
+<header class="bg-white/95 dark:bg-slate-950/80 backdrop-blur-md border-b border-gray-200/80 dark:border-slate-800/60 sticky top-0 z-50 transition-colors dark:shadow-lg dark:shadow-slate-950/50">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
       <!-- Logo -->
       <div class="flex items-center space-x-2">
         <Logo />
-        <div class="font-bold text-xl text-gray-900 dark:text-gray-100">
+        <div class="font-bold text-xl text-gray-900 dark:text-slate-100">
           Build<span class="text-blue-600 dark:text-blue-400">AtScale</span>
         </div>
       </div>
 
       <!-- Navigation -->
       <nav class="hidden md:flex items-center space-x-8">
-        <a href="#latest" class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium">
+        <a href="#latest" class="text-gray-600 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium">
           Videos
         </a>
-        <a href="#about" class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium">
+        <a href="#about" class="text-gray-600 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium">
           About
         </a>
-        <a href="#topics" class="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium">
+        <a href="#topics" class="text-gray-600 dark:text-slate-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors font-medium">
           Topics
         </a>
       </nav>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,16 +1,21 @@
 ---
 ---
 
-<section class="bg-gradient-to-b from-blue-50 to-white dark:from-slate-700 dark:to-slate-800 pt-20 pb-10 transition-colors">
+<section class="bg-gradient-to-b from-blue-50 to-white dark:from-slate-900 dark:via-slate-900 dark:to-slate-950 pt-20 pb-10 transition-colors relative overflow-hidden">
+  <!-- Subtle aurora-like background glow for dark mode -->
+  <div class="absolute inset-0 dark:block hidden pointer-events-none">
+    <div class="absolute top-0 left-1/4 w-96 h-96 bg-blue-600/10 rounded-full blur-3xl"></div>
+    <div class="absolute bottom-0 right-1/4 w-80 h-80 bg-indigo-600/10 rounded-full blur-3xl"></div>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-16">
-      <h1 class="text-5xl lg:text-6xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+      <h1 class="text-5xl lg:text-6xl font-bold text-gray-900 dark:text-slate-100 mb-6">
         Learning in Public
       </h1>
-      <p class="text-xl lg:text-2xl text-gray-600 dark:text-gray-300 mb-4 max-w-4xl mx-auto">
+      <p class="text-xl lg:text-2xl text-gray-600 dark:text-slate-300 mb-4 max-w-4xl mx-auto">
         AI • Web • Ops
       </p>
-      <p class="text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto leading-relaxed">
+      <p class="text-lg text-gray-600 dark:text-slate-400 mb-8 max-w-3xl mx-auto leading-relaxed">
         Sharing what I'm building, breaking, and learning. From LLM experiments and web dev deep dives
         to DevOps automation and shipping fast.
       </p>
@@ -19,7 +24,7 @@
           href="https://youtube.com/@buildatscale"
           target="_blank"
           rel="noopener"
-          class="bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white px-8 py-3 rounded-lg font-medium transition-colors flex items-center space-x-2"
+          class="bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-500 text-white px-8 py-3 rounded-lg font-medium transition-colors flex items-center space-x-2 dark:shadow-lg dark:shadow-blue-900/30"
         >
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
             <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
@@ -28,7 +33,7 @@
         </a>
         <a
           href="#latest"
-          class="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-3 rounded-lg font-medium transition-colors"
+          class="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white dark:border-blue-400 dark:text-blue-400 dark:hover:bg-blue-500 dark:hover:text-white dark:hover:border-blue-500 px-8 py-3 rounded-lg font-medium transition-colors"
         >
           Browse Videos
         </a>

--- a/src/components/LatestVideos.astro
+++ b/src/components/LatestVideos.astro
@@ -67,13 +67,17 @@ const videosData = sortedVideos.map(video => ({
 }));
 ---
 
-<section id="videos" class="py-16 bg-gray-50 dark:bg-slate-700 transition-colors">
+<section id="videos" class="py-16 bg-gray-50 dark:bg-slate-950 transition-colors relative">
+  <div class="absolute inset-0 dark:block hidden pointer-events-none">
+    <div class="absolute top-0 right-0 w-72 h-72 bg-indigo-500/5 rounded-full blur-3xl"></div>
+    <div class="absolute bottom-0 left-0 w-80 h-80 bg-blue-500/5 rounded-full blur-3xl"></div>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
-      <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+      <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-slate-100 mb-4">
         More Videos
       </h2>
-      <p class="text-lg text-gray-600 dark:text-gray-300">
+      <p class="text-lg text-gray-600 dark:text-slate-400">
         Explore more content on AI orchestration and development workflows
       </p>
     </div>
@@ -87,8 +91,8 @@ const videosData = sortedVideos.map(video => ({
           data-video-ids={JSON.stringify(playlist.videoIds)}
           class={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 ${
             index === 0
-              ? 'bg-blue-600 text-white shadow-md'
-              : 'bg-white dark:bg-slate-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-500 border border-gray-200 dark:border-slate-500'
+              ? 'bg-blue-600 text-white shadow-md dark:shadow-blue-900/30'
+              : 'bg-white dark:bg-slate-900/60 text-gray-700 dark:text-slate-300 hover:bg-gray-100 dark:hover:bg-slate-800/80 border border-gray-200 dark:border-slate-700/50 dark:backdrop-blur-sm'
           }`}
         >
           {playlist.label}
@@ -98,7 +102,7 @@ const videosData = sortedVideos.map(video => ({
 
     <!-- No Results Message (hidden by default) -->
     <div id="no-results" class="hidden text-center py-12">
-      <p class="text-gray-600 dark:text-gray-400">No videos found for this filter. Try a different category.</p>
+      <p class="text-gray-600 dark:text-slate-400">No videos found for this filter. Try a different category.</p>
     </div>
 
     {hasVideos ? (
@@ -124,7 +128,7 @@ const videosData = sortedVideos.map(video => ({
       </div>
     ) : (
       <div class="text-center py-12">
-        <p class="text-gray-600 dark:text-gray-400">Loading videos...</p>
+        <p class="text-gray-600 dark:text-slate-400">Loading videos...</p>
       </div>
     )}
 
@@ -134,7 +138,7 @@ const videosData = sortedVideos.map(video => ({
         data-videos={JSON.stringify(videosData)}
         data-most-popular={mostPopularVideo?.id}
         data-total={totalVideos}
-        class="inline-flex items-center space-x-2 bg-gray-100 hover:bg-gray-200 dark:bg-slate-600 dark:hover:bg-slate-500 text-gray-900 dark:text-gray-100 px-6 py-3 rounded-lg font-medium transition-colors"
+        class="inline-flex items-center space-x-2 bg-gray-100 hover:bg-gray-200 dark:bg-slate-800/70 dark:hover:bg-slate-700/80 text-gray-900 dark:text-slate-100 px-6 py-3 rounded-lg font-medium transition-colors dark:border dark:border-slate-700/50 dark:backdrop-blur-sm"
       >
         <span id="btn-text">View More Videos</span>
         <svg id="btn-icon-more" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -149,8 +153,8 @@ const videosData = sortedVideos.map(video => ({
 </section>
 
 <WaveTransition
-  topColor="fill-gray-50 dark:fill-slate-700"
-  bottomColor="fill-blue-50 dark:fill-slate-800"
+  topColor="fill-gray-50 dark:fill-slate-950"
+  bottomColor="fill-blue-50 dark:fill-slate-900"
 />
 
 <script>
@@ -266,9 +270,9 @@ const videosData = sortedVideos.map(video => ({
           <button
             type="button"
             onclick="openVideoModal('${video.id}', '${escapedTitle}')"
-            class="bg-white dark:bg-slate-600/50 backdrop-blur-sm border border-gray-200 dark:border-slate-500 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-slate-700/30 transition-all duration-300 group cursor-pointer block w-full text-left"
+            class="bg-white dark:bg-slate-900/60 backdrop-blur-sm border border-gray-200 dark:border-slate-700/50 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-slate-950/50 transition-all duration-300 group cursor-pointer block w-full text-left dark:hover:ring-1 dark:hover:ring-slate-600/50"
           >
-            <div class="relative aspect-video bg-gray-100 dark:bg-gray-800">
+            <div class="relative aspect-video bg-gray-100 dark:bg-slate-800/80">
               <img
                 src="${video.thumbnail}"
                 alt="${video.title}"
@@ -292,10 +296,10 @@ const videosData = sortedVideos.map(video => ({
               </div>` : ''}
             </div>
             <div class="p-4">
-              <h3 class="font-semibold text-gray-900 dark:text-gray-100 mb-2 line-clamp-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors text-sm h-10">
+              <h3 class="font-semibold text-gray-900 dark:text-slate-100 mb-2 line-clamp-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors text-sm h-10">
                 ${video.title}
               </h3>
-              <div class="flex items-center text-xs text-gray-500 dark:text-gray-400 space-x-2">
+              <div class="flex items-center text-xs text-gray-500 dark:text-slate-400 space-x-2">
                 <div class="flex items-center">
                   <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -392,11 +396,11 @@ const videosData = sortedVideos.map(video => ({
 
         // Update active state
         filterButtons.forEach(btn => {
-          btn.classList.remove('bg-blue-600', 'text-white', 'shadow-md');
-          btn.classList.add('bg-white', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-slate-500', 'border', 'border-gray-200', 'dark:border-slate-500');
+          btn.classList.remove('bg-blue-600', 'text-white', 'shadow-md', 'dark:shadow-blue-900/30');
+          btn.classList.add('bg-white', 'dark:bg-slate-900/60', 'text-gray-700', 'dark:text-slate-300', 'hover:bg-gray-100', 'dark:hover:bg-slate-800/80', 'border', 'border-gray-200', 'dark:border-slate-700/50');
         });
-        button.classList.remove('bg-white', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-200', 'hover:bg-gray-100', 'dark:hover:bg-slate-500', 'border', 'border-gray-200', 'dark:border-slate-500');
-        button.classList.add('bg-blue-600', 'text-white', 'shadow-md');
+        button.classList.remove('bg-white', 'dark:bg-slate-900/60', 'text-gray-700', 'dark:text-slate-300', 'hover:bg-gray-100', 'dark:hover:bg-slate-800/80', 'border', 'border-gray-200', 'dark:border-slate-700/50');
+        button.classList.add('bg-blue-600', 'text-white', 'shadow-md', 'dark:shadow-blue-900/30');
 
         currentFilter = filterId;
         renderFilteredVideos();

--- a/src/components/MostRecentVideo.astro
+++ b/src/components/MostRecentVideo.astro
@@ -31,19 +31,22 @@ const latestVideo = hasVideos ? {
 ---
 
 <WaveTransition
-  topColor="fill-white dark:fill-slate-800"
-  bottomColor="fill-gray-50 dark:fill-slate-700"
+  topColor="fill-white dark:fill-slate-950"
+  bottomColor="fill-gray-50 dark:fill-slate-900"
 />
 
-<section id="latest" class="pt-10 pb-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-slate-700 transition-colors">
+<section id="latest" class="pt-10 pb-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-slate-900 transition-colors relative">
+  <div class="absolute inset-0 dark:block hidden pointer-events-none">
+    <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[400px] bg-blue-500/5 rounded-full blur-3xl"></div>
+  </div>
   <div class="max-w-7xl mx-auto">
     {hasVideos && latestVideo ? (
       <div class="max-w-4xl mx-auto">
         <div class="text-center mb-6">
-          <span class="inline-block bg-green-100 dark:bg-green-700/30 text-green-700 dark:text-green-300 px-3 py-1 rounded-full text-sm font-medium mb-4">
+          <span class="inline-block bg-green-100 dark:bg-green-500/15 text-green-700 dark:text-green-300 px-3 py-1 rounded-full text-sm font-medium mb-4 border border-green-200 dark:border-green-500/20">
             Latest Video
           </span>
-          <h2 class="text-2xl lg:text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h2 class="text-2xl lg:text-3xl font-bold text-gray-900 dark:text-slate-100">
             {latestVideo.title}
           </h2>
         </div>
@@ -53,7 +56,7 @@ const latestVideo = hasVideos ? {
           onclick={`openVideoModal('${latestVideo.videoId}', '${latestVideo.title.replace(/'/g, "\\'")}')`}
           class="relative group cursor-pointer block w-full"
         >
-          <div class="relative aspect-video bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden shadow-2xl">
+          <div class="relative aspect-video bg-gray-200 dark:bg-slate-800 rounded-lg overflow-hidden shadow-2xl dark:shadow-slate-950/60 ring-1 dark:ring-slate-700/50">
             <img
               src={latestVideo.thumbnail}
               alt={latestVideo.title}
@@ -72,7 +75,7 @@ const latestVideo = hasVideos ? {
             </div>
           </div>
 
-          <div class="flex items-center justify-center mt-6 text-gray-600 dark:text-gray-300 space-x-6 flex-nowrap">
+          <div class="flex items-center justify-center mt-6 text-gray-600 dark:text-slate-300 space-x-6 flex-nowrap">
             <div class="flex items-center whitespace-nowrap">
               <svg class="w-4 h-4 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -94,7 +97,7 @@ const latestVideo = hasVideos ? {
       </div>
     ) : (
       <div class="max-w-4xl mx-auto text-center">
-        <p class="text-gray-600 dark:text-gray-300">Loading most recent video...</p>
+        <p class="text-gray-600 dark:text-slate-400">Loading most recent video...</p>
       </div>
     )}
   </div>

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -10,50 +10,50 @@ const interests = [
 ---
 
 <!-- Subtle divider between forms -->
-<div class="bg-blue-50 dark:bg-slate-800">
+<div class="bg-blue-50 dark:bg-slate-950">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center gap-4 py-8">
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-800 to-transparent"></div>
       <div class="flex gap-1.5">
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-400"></div>
-        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-500"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-700"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-400 dark:bg-slate-600"></div>
+        <div class="w-1.5 h-1.5 rounded-full bg-blue-300 dark:bg-slate-700"></div>
       </div>
-      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-600 to-transparent"></div>
+      <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200 dark:via-slate-800 to-transparent"></div>
     </div>
   </div>
 </div>
 
-<section class="py-12 pb-24 bg-blue-50 dark:bg-slate-800 text-gray-900 dark:text-white">
+<section class="py-12 pb-24 bg-blue-50 dark:bg-slate-950 text-gray-900 dark:text-white">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
       <h2 class="text-3xl lg:text-4xl font-bold mb-4">
         Stay Updated
       </h2>
-      <p class="text-lg text-gray-600 dark:text-gray-300">
+      <p class="text-lg text-gray-600 dark:text-slate-400">
         Get notified when I publish new content about AI orchestration, development workflows,
         and the latest experiments. No spam, just valuable insights.
       </p>
     </div>
 
-    <div class="bg-white dark:bg-slate-700/50 backdrop-blur-sm rounded-lg p-8 shadow-lg dark:shadow-slate-700/50 border border-gray-200 dark:border-slate-600">
+    <div class="bg-white dark:bg-slate-900/60 backdrop-blur-sm rounded-lg p-8 shadow-lg dark:shadow-slate-950/50 border border-gray-200 dark:border-slate-700/50">
       <form id="newsletter-form" class="space-y-6">
         <div>
-          <label for="signup-email" class="block text-sm font-medium text-gray-700 dark:text-gray-400 mb-2">
+          <label for="signup-email" class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
             Email Address
           </label>
           <input
             type="email"
             id="signup-email"
             name="email"
-            class="w-full px-4 py-3 bg-white dark:bg-slate-600/80 border border-gray-300 dark:border-slate-500 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            class="w-full px-4 py-3 bg-white dark:bg-slate-800/60 border border-gray-300 dark:border-slate-700/50 rounded-lg text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             placeholder="your@email.com"
             required
           />
         </div>
 
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-400 mb-3">
+          <label class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-3">
             What interests you most? (Optional)
           </label>
           <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
@@ -61,7 +61,7 @@ const interests = [
               <button
                 type="button"
                 data-interest={interest}
-                class="interest-btn px-3 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-slate-600 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-slate-500 border border-gray-300 dark:border-slate-500 break-words text-center min-h-[2.5rem] flex items-center justify-center"
+                class="interest-btn px-3 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-100 dark:bg-slate-800/60 text-gray-700 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-slate-700/80 border border-gray-300 dark:border-slate-700/50 break-words text-center min-h-[2.5rem] flex items-center justify-center"
               >
                 {interest}
               </button>
@@ -90,7 +90,7 @@ const interests = [
 
           <div id="newsletter-error" class="text-red-600 dark:text-red-400 font-medium text-sm hidden"></div>
 
-          <p class="text-xs text-gray-500 dark:text-gray-400">
+          <p class="text-xs text-gray-500 dark:text-slate-400">
             No spam, ever. Unsubscribe at any time. I respect your privacy and will only send valuable content updates.
           </p>
         </div>
@@ -119,10 +119,10 @@ const interests = [
         if (selectedInterests.has(interest)) {
           selectedInterests.delete(interest);
           btn.classList.remove('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
-          btn.classList.add('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
+          btn.classList.add('bg-gray-100', 'dark:bg-slate-800/60', 'text-gray-700', 'dark:text-slate-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-700/80', 'border-gray-300', 'dark:border-slate-700/50');
         } else {
           selectedInterests.add(interest);
-          btn.classList.remove('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
+          btn.classList.remove('bg-gray-100', 'dark:bg-slate-800/60', 'text-gray-700', 'dark:text-slate-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-700/80', 'border-gray-300', 'dark:border-slate-700/50');
           btn.classList.add('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
         }
       }
@@ -181,7 +181,7 @@ const interests = [
       selectedInterests.clear();
       interestBtns.forEach(btn => {
         btn.classList.remove('bg-blue-600', 'hover:bg-blue-700', 'text-white', 'border-blue-600');
-        btn.classList.add('bg-gray-100', 'dark:bg-slate-600', 'text-gray-700', 'dark:text-gray-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-500', 'border-gray-300', 'dark:border-slate-500');
+        btn.classList.add('bg-gray-100', 'dark:bg-slate-800/60', 'text-gray-700', 'dark:text-slate-300', 'hover:bg-gray-200', 'dark:hover:bg-slate-700/80', 'border-gray-300', 'dark:border-slate-700/50');
       });
 
       // Hide success message after 3 seconds

--- a/src/components/RequestForm.astro
+++ b/src/components/RequestForm.astro
@@ -8,55 +8,55 @@ const requestTypes = [
 ];
 ---
 
-<section class="py-8 pb-12 bg-blue-50 dark:bg-slate-800">
+<section class="py-8 pb-12 bg-blue-50 dark:bg-slate-950">
   <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
-      <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">
+      <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 dark:text-slate-100 mb-4">
         Have an Idea or Request?
       </h2>
-      <p class="text-lg text-gray-600 dark:text-gray-300">
+      <p class="text-lg text-gray-600 dark:text-slate-400">
         Suggest a topic, share a problem you're facing, or request a video.
         I'm always looking for real-world challenges to explore.
       </p>
     </div>
 
-    <div class="bg-white dark:bg-slate-700/50 backdrop-blur-sm rounded-lg shadow-lg dark:shadow-slate-700/50 p-8 border border-transparent dark:border-slate-600">
+    <div class="bg-white dark:bg-slate-900/60 backdrop-blur-sm rounded-lg shadow-lg dark:shadow-slate-950/50 p-8 border border-gray-200 dark:border-slate-700/50">
       <form id="request-form" class="space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Name
-            </label>
-            <input
-              type="text"
-              id="name"
-              name="name"
-              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              required
-            />
+          <label for="name" class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+            Name
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-700/50 bg-white dark:bg-slate-800/60 text-gray-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:placeholder-slate-500"
+            required
+          />
           </div>
           <div>
-            <label for="request-email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              Email
-            </label>
-            <input
-              type="email"
-              id="request-email"
-              name="email"
-              class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              required
-            />
+          <label for="request-email" class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
+            Email
+          </label>
+          <input
+            type="email"
+            id="request-email"
+            name="email"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-700/50 bg-white dark:bg-slate-800/60 text-gray-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:placeholder-slate-500"
+            required
+          />
           </div>
         </div>
 
         <div>
-          <label for="type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          <label for="type" class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
             Request Type
           </label>
           <select
             id="type"
             name="type"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent [&>option]:bg-white [&>option]:dark:bg-slate-800 [&>option]:text-gray-900 [&>option]:dark:text-gray-100"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-700/50 bg-white dark:bg-slate-800/60 text-gray-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent [&>option]:bg-white [&>option]:dark:bg-slate-900 [&>option]:text-gray-900 [&>option]:dark:text-slate-100"
           >
             {requestTypes.map((type) => (
               <option value={type}>{type}</option>
@@ -65,14 +65,14 @@ const requestTypes = [
         </div>
 
         <div>
-          <label for="message" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          <label for="message" class="block text-sm font-medium text-gray-700 dark:text-slate-300 mb-2">
             Details
           </label>
           <textarea
             id="message"
             name="message"
             rows="4"
-            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700/50 text-gray-900 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400 dark:placeholder-gray-500"
+            class="w-full px-4 py-2 border border-gray-300 dark:border-slate-700/50 bg-white dark:bg-slate-800/60 text-gray-900 dark:text-slate-100 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder-gray-400 dark:placeholder-slate-500"
             placeholder="Describe your idea, problem, or request in detail..."
             required
           ></textarea>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,7 +6,7 @@
   <button
     id="theme-toggle"
     type="button"
-    class="p-2 rounded-lg bg-gray-100 dark:bg-slate-800 hover:bg-gray-200 dark:hover:bg-slate-700 transition-colors border border-transparent dark:border-slate-700"
+    class="p-2 rounded-lg bg-gray-100 dark:bg-slate-800/60 hover:bg-gray-200 dark:hover:bg-slate-700/80 transition-colors border border-transparent dark:border-slate-700/60 dark:shadow-sm dark:shadow-slate-900/30"
     aria-label="Toggle theme"
   >
     <svg id="theme-icon-light" class="w-5 h-5 text-gray-800 dark:text-gray-200 hidden" fill="currentColor" viewBox="0 0 20 20">

--- a/src/components/VideoCard.astro
+++ b/src/components/VideoCard.astro
@@ -21,10 +21,10 @@ const timeAgo = getTimeAgo(publishedAt);
 <button
   type="button"
   onclick={`openVideoModal('${videoId}', '${title.replace(/'/g, "\\'")}')`}
-  class="bg-white dark:bg-slate-600/50 backdrop-blur-sm border border-gray-200 dark:border-slate-500 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-slate-700/30 transition-all duration-300 group cursor-pointer block w-full text-left"
+  class="bg-white dark:bg-slate-900/60 backdrop-blur-sm border border-gray-200 dark:border-slate-700/50 rounded-lg overflow-hidden hover:shadow-lg dark:hover:shadow-slate-950/50 transition-all duration-300 group cursor-pointer block w-full text-left dark:hover:ring-1 dark:hover:ring-slate-600/50"
 >
   <!-- Video Thumbnail -->
-  <div class="relative aspect-video bg-gray-100 dark:bg-gray-800">
+  <div class="relative aspect-video bg-gray-100 dark:bg-slate-800/80">
     <img
       src={thumbnail}
       alt={title}
@@ -47,10 +47,10 @@ const timeAgo = getTimeAgo(publishedAt);
 
   <!-- Video Info -->
   <div class="p-4">
-    <h3 class="font-semibold text-gray-900 dark:text-gray-100 mb-2 line-clamp-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors text-sm h-10">
+    <h3 class="font-semibold text-gray-900 dark:text-slate-100 mb-2 line-clamp-2 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors text-sm h-10">
       {title}
     </h3>
-    <div class="flex items-center text-xs text-gray-500 dark:text-gray-400 space-x-2 flex-nowrap">
+    <div class="flex items-center text-xs text-gray-500 dark:text-slate-400 space-x-2 flex-nowrap">
       <div class="flex items-center whitespace-nowrap">
         <svg class="w-3 h-3 mr-1 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>

--- a/src/components/VideoModal.astro
+++ b/src/components/VideoModal.astro
@@ -4,12 +4,12 @@
 ---
 
 <dialog id="video-modal" class="backdrop:bg-black backdrop:bg-opacity-75 bg-transparent p-0 max-w-6xl w-full rounded-lg">
-  <div class="bg-white dark:bg-slate-700 rounded-lg overflow-hidden shadow-2xl border border-transparent dark:border-slate-600">
-    <div class="flex items-center justify-between p-4 bg-gray-100 dark:bg-slate-600 text-gray-900 dark:text-white border-b border-gray-200 dark:border-slate-500">
-      <h3 id="video-modal-title" class="text-lg font-semibold text-gray-900 dark:text-white"></h3>
+  <div class="bg-white dark:bg-slate-900 rounded-lg overflow-hidden shadow-2xl border border-transparent dark:border-slate-700/60">
+    <div class="flex items-center justify-between p-4 bg-gray-100 dark:bg-slate-800 text-gray-900 dark:text-slate-100 border-b border-gray-200 dark:border-slate-700/60">
+      <h3 id="video-modal-title" class="text-lg font-semibold text-gray-900 dark:text-slate-100"></h3>
       <button
         id="close-video-modal"
-        class="text-gray-900 dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+        class="text-gray-900 dark:text-slate-300 hover:text-gray-600 dark:hover:text-slate-100 transition-colors"
         aria-label="Close video"
       >
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,7 +20,7 @@ const { title, description = "Learning in Public — AI • Web • Ops" } = Ast
     <title>{title}</title>
     <ThemeScript />
   </head>
-  <body class="min-h-screen bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 transition-colors">
+  <body class="min-h-screen bg-white dark:bg-slate-950 text-gray-900 dark:text-slate-100 transition-colors">
     <slot />
   </body>
 </html>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -10,14 +10,14 @@ import Footer from '../components/Footer.astro';
 >
   <Header />
   <main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-    <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Privacy Policy</h1>
-    <p class="text-sm text-gray-500 dark:text-gray-400 mb-10">BuildAtScale / Build Test Run LLC — Last updated: February 2026</p>
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-slate-100 mb-2">Privacy Policy</h1>
+    <p class="text-sm text-gray-500 dark:text-slate-400 mb-10">BuildAtScale / Build Test Run LLC — Last updated: February 2026</p>
 
     <div class="prose prose-gray dark:prose-invert max-w-none space-y-8">
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Overview</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Overview</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           This privacy policy describes how BuildAtScale (operated by Build Test Run LLC, "we," "us," or "our") collects,
           uses, and shares information when you visit buildatscale.tv (the "Site"). We keep this simple because we don't
           do anything complicated with your data.
@@ -25,109 +25,109 @@ import Footer from '../components/Footer.astro';
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Information We Collect</h2>
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Information We Collect</h2>
 
-        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">Information You Provide</h3>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+        <h3 class="text-base font-semibold text-gray-800 dark:text-slate-200 mb-2">Information You Provide</h3>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mb-4">
           We only collect information you voluntarily provide, such as your email address if you sign up for a newsletter
           or contact us directly. We don't have account registration, comment systems, or forms that collect personal
           information beyond basic contact.
         </p>
 
-        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">Information Collected Automatically</h3>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-3">
+        <h3 class="text-base font-semibold text-gray-800 dark:text-slate-200 mb-2">Information Collected Automatically</h3>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mb-3">
           When you visit the Site, standard web server logs and analytics tools may collect:
         </p>
-        <ul class="list-disc list-inside text-gray-700 dark:text-gray-300 space-y-1 ml-2">
+        <ul class="list-disc list-inside text-gray-700 dark:text-slate-300 space-y-1 ml-2">
           <li>IP address</li>
           <li>Browser type and version</li>
           <li>Pages visited and time spent</li>
           <li>Referring URLs</li>
           <li>Device type</li>
         </ul>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mt-3">
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mt-3">
           This information is used in aggregate to understand how people use the Site and is not used to identify individuals.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Third-Party Services</h2>
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Third-Party Services</h2>
 
-        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">YouTube</h3>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-4">
+        <h3 class="text-base font-semibold text-gray-800 dark:text-slate-200 mb-2">YouTube</h3>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mb-4">
           This Site embeds video content from YouTube. Content embedded from YouTube is subject to
           <a href="https://policies.google.com/privacy" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 hover:underline">YouTube's Privacy Policy</a>.
           YouTube may collect data when you interact with embedded videos.
         </p>
 
-        <h3 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">Affiliate Links</h3>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h3 class="text-base font-semibold text-gray-800 dark:text-slate-200 mb-2">Affiliate Links</h3>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           Some links on this Site may be affiliate links. Clicking these links may result in us earning a commission.
           We only link to products and services we genuinely use or recommend.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Cookies</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Cookies</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           This Site uses cookies for basic functionality. You can control cookies through your browser settings.
           Disabling cookies may affect some site functionality.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">How We Use Your Information</h2>
-        <ul class="list-disc list-inside text-gray-700 dark:text-gray-300 space-y-1 ml-2">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">How We Use Your Information</h2>
+        <ul class="list-disc list-inside text-gray-700 dark:text-slate-300 space-y-1 ml-2">
           <li>To operate and improve the Site</li>
           <li>To understand how visitors use the Site</li>
           <li>To respond to direct inquiries</li>
           <li>To send newsletters if you have subscribed (you can unsubscribe at any time)</li>
         </ul>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mt-4 font-medium">
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mt-4 font-medium">
           We do not sell your personal information to third parties. Ever.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Data Retention</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Data Retention</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           Email addresses collected for newsletters are retained until you unsubscribe. Contact form submissions are
           retained only as long as necessary to respond.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Your Rights</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-3">You have the right to:</p>
-        <ul class="list-disc list-inside text-gray-700 dark:text-gray-300 space-y-1 ml-2">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Your Rights</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mb-3">You have the right to:</p>
+        <ul class="list-disc list-inside text-gray-700 dark:text-slate-300 space-y-1 ml-2">
           <li>Request access to any personal data we hold about you</li>
           <li>Request deletion of your personal data</li>
           <li>Opt out of any communications from us</li>
         </ul>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mt-3">
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed mt-3">
           To exercise these rights, contact us at the email below.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Children's Privacy</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Children's Privacy</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           This Site is not directed at children under 13. We do not knowingly collect personal information from children
           under 13. If you believe we have inadvertently collected such information, contact us and we will delete it promptly.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Changes to This Policy</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Changes to This Policy</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           We may update this policy from time to time. The "last updated" date at the top of this page will reflect any
           changes. Continued use of the Site after changes constitutes acceptance of the updated policy.
         </p>
       </section>
 
       <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">Contact</h2>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+        <h2 class="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-3">Contact</h2>
+        <p class="text-gray-700 dark:text-slate-300 leading-relaxed">
           Build Test Run LLC<br />
           <a href="mailto:hello@buildatscale.tv" class="text-blue-600 dark:text-blue-400 hover:underline">hello@buildatscale.tv</a><br />
           buildatscale.tv


### PR DESCRIPTION
Refreshed the dark mode design across the entire site to move away from the previous flat slate-800 look. Switched to a deeper slate-950 base with layered translucent surfaces, subtle aurora glows in the hero and video sections, and refined borders and shadows for better depth and visual hierarchy. Text contrast and accent colors were also tuned for a more modern, polished feel in dark mode.

Request:
> Variant 2 of 3: dark mode facelift/refresh. Want to focus specifically on the design in dark mode. it currently looks a bit dated / flat. want to improve overall.